### PR TITLE
ttc-connectors-dummytwitter to 1.0.40

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.13
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.40


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.40